### PR TITLE
Add the encryption Nonce explicitely to the SealedBox schema

### DIFF
--- a/Schema/SealedBox.schema.json
+++ b/Schema/SealedBox.schema.json
@@ -12,17 +12,23 @@
         "encryptedVault": {
             "type": "string",
             "format": "base64",
-            "description": "Encrypted Vault using with shared key between vault receiver and provider."
+            "description": "Encrypted Vault using with shared key between vault receiver and provider. In the format of `encryptedData || authenticationTag`"
         },
         "keyDerivationSalt": {
             "type": "string",
             "format": "base64",
             "description": "Salt used for symmetric key derivation."
+        },
+        "encryptionNonce": {
+            "type": "string",
+            "format": "base64",
+            "description": "Nonce used in the encryption of the vault"
         }
     },
     "required": [
         "publicKey",
         "encryptedVault",
-        "keyDerivationSalt"
+        "keyDerivationSalt",
+        "encryptionNonce"
     ]
 }


### PR DESCRIPTION
When reviewing the swift code and writing the equivalent rust example, I noticed that we let the nonce default to `nil` in the [seal](https://developer.apple.com/documentation/cryptokit/aes/gcm/seal(_:using:nonce:)) method. Afterwards we call the [combined](https://developer.apple.com/documentation/cryptokit/aes/gcm/sealedbox#retrieving-the-combined-contents) property on `AES.GCM.SealedBox` which concatenates the nonce, encrypted data and authentication tag together in that order.

While the concatenation of the `encryptedData || AuthenticationTag` is standard in this kind of operation across cryptographic ecosystems, however the nonce is usually separate. 