### PR TITLE
Add session identifiers to OpenBox and SealedBox schemas.

### DIFF
--- a/Schema/OpenBox.schema.json
+++ b/Schema/OpenBox.schema.json
@@ -8,6 +8,10 @@
             "type": "string",
             "format": "base64",
             "description": "Public Key of the Vault receiver used to share the vault content symmetric key with the vault source."
+        },
+        "sessionIdentifier": {
+            "type": "string",
+            "description": "Non-secret session identifier to help receiving applications match incoming SealedBoxes with the corresponding private key. Originating apps should include this in their SealedBox."
         }
     },
     "required": [

--- a/Schema/SealedBox.schema.json
+++ b/Schema/SealedBox.schema.json
@@ -28,6 +28,10 @@
             "type": "string",
             "format": "base64",
             "description": "The authentication tag of the `encryptedVault`"
+        },
+        "sessionIdentifier": {
+            "type": "string",
+            "description": "Non-secret session identifier to help receiving applications match incoming SealedBoxes with the corresponding private key that was shared in the OpenBox."
         }
     },
     "required": [


### PR DESCRIPTION
I was thinking about this today and realised that the following confusion could arise:

* User possibly has a number of OpenBox public key files lying around, generates another one
* User presents a random OpenBox file to the exporting app
* The exporting app encrypts data with that key
* The receiving app receives a SealedBox encrypted with a key that does not correspond with its most-recently-created OpenBox secret key.

If we add a non-secret session identifier to each OpenBox, the receiving app could keep multiple secret keys around and choose the one that matches the session identifier of the received OpenBox.

Further, if the receiving app receives a SealedBox containing a session identifier that it did not originate, it would likely enable the receiving app to give the user a much more helpful error message than just saying "decryption failed".

Feel free to drop if there's already something in the cryptography that can peform this function.